### PR TITLE
Set retention, daily quota and worker defaults

### DIFF
--- a/JanssenIo.ReviewBot.Functions/JanssenIo.ReviewBot.Functions.csproj
+++ b/JanssenIo.ReviewBot.Functions/JanssenIo.ReviewBot.Functions.csproj
@@ -8,11 +8,9 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />

--- a/JanssenIo.ReviewBot.Functions/Program.cs
+++ b/JanssenIo.ReviewBot.Functions/Program.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Options;
 using StoreConfiguration = JanssenIo.ReviewBot.Functions.StoreConfiguration;
 
 var host = new HostBuilder()
-    .ConfigureFunctionsWebApplication()
+    .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices(services =>
     {
         services.AddApplicationInsightsTelemetryWorkerService();

--- a/reviewbot.bicep
+++ b/reviewbot.bicep
@@ -38,6 +38,7 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
     properties:{
       retentionInDays: 30
       totalRetentionInDays: 30
+      plan: 'Analytics'
       schema: {
         name: table
       }

--- a/reviewbot.bicep
+++ b/reviewbot.bicep
@@ -2,6 +2,21 @@ param botId string
 param packageUrl string
 param location string = resourceGroup().location
 
+var tablesExemptFromWorkspaceRetention = [
+  'AppAvailabilityResults'
+  'AppBrowserTimings'
+  'AppDependencies'
+  'AppEvents'
+  'AppExceptions'
+  'AppMetrics'
+  'AppPageViews'
+  'AppPerformanceCounters'
+  'AppRequests'
+  'AppSystemEvents'
+  'AppTraces'
+  'AzureActivity'
+  'Usage'
+]
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: 'jio-reddit-logs'
   location: location
@@ -17,6 +32,17 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'
   }
+
+  resource appTable 'tables@2022-10-01' = [for table in tablesExemptFromWorkspaceRetention: {
+    name: table
+    properties:{
+      retentionInDays: 30
+      totalRetentionInDays: 30
+      schema: {
+        name: table
+      }
+    }
+  }]
 }
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
@@ -48,6 +74,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   }
 }
 
+// Deployed by hand, because only one free tier can exist in the subscription
 resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' existing = {
   name: 'jio-flockbots-cdb'
 }
@@ -94,6 +121,7 @@ resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
   properties: {
     reserved: true
     serverFarmId: hostingPlan.id
+    dailyMemoryTimeQuota: 15000
     siteConfig: {
       linuxFxVersion: 'DOTNET-ISOLATED|8.0'
       appSettings: [


### PR DESCRIPTION
- Not all tables adhere to the workspace default retention. To reduce costs, also set these tables to maximum 30 days.
- In case the function goes out of whack, prevent costs by limiting it to slightly above the free 400.000 / 28 (days) GB/s memory.
- Since there is no HTTP Trigger, there is no use to include ASP.NET packages.